### PR TITLE
feat: add module to setup env for providers

### DIFF
--- a/src/commands/environment.ts
+++ b/src/commands/environment.ts
@@ -1,7 +1,5 @@
-import fs from "fs"
-import path from "path"
 import { createSpinner } from "nanospinner"
-import { execAsync, ROOT } from "../utils.js"
+import { execAsync, setEnvironment } from "../utils.js"
 
 
 /**
@@ -9,21 +7,13 @@ import { execAsync, ROOT } from "../utils.js"
  * the AUTH_SECRET variable. This is mandatory for using auth.js without considering
  * the framework.
  */
-export const setEnvironment = async (): Promise<void> => {
-    const environmentPath = path.join(ROOT, ".env")
-    const existVariable = process.env.AUTH_SECRET ?? process.env.NEXT_AUTH
-
-    if(!existVariable) {
-        const spinner = createSpinner("Setting up the environment variables of the project").start()
-        try {
-            const randomized = await getRandonSecret()
-            fs.writeFileSync(environmentPath, `AUTH_SECRET=${randomized}`)
-            spinner.success({ text: "The AUTH_SECRET variable was created" })
-        } catch(error) {
-            spinner.error({ text: "An error occurred while generating the secret key" })
-        }
+export const setAuthConfigEnvironment = async (): Promise<void> => {
+    try {
+        const randomized = await getRandonSecret()
+        setEnvironment("AUTH_SECRET", randomized)
+    } catch(error) {
+        createSpinner("Error").error({ text: "An error occurred while generating the secret key" })
     }
-    createSpinner("The AUTH_SECRENT already exists").warn()
 }
 
 
@@ -33,7 +23,7 @@ export const setEnvironment = async (): Promise<void> => {
  * 
  * @returns {Promise<string>} The generated secret key
  */
-const getRandonSecret = async () => {
+export const getRandonSecret = async (): Promise<string> => {
     const { stdout } = await execAsync("openssl rand -base64 33")
     return stdout
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,8 @@
 import "dotenv/config.js"
 import { FlagOptions } from "./types.js"
 import { Command } from "commander"
-import { setEnvironment } from "./commands/environment.js"
-import { promptInitConfig } from "./prompts/init.js"
+import { setAuthConfigEnvironment } from "./commands/environment.js"
+import { promptInitProviders } from "./prompts/providers.js"
 
 
 /**
@@ -25,9 +25,13 @@ program
  */
 program
     .option("-s, --secret", "Generate the secret key")
+    .option("-p, --providers", "Select the provider to be initialized")
     .action(async (flags: FlagOptions) => {
         if(flags.secret) {
-            await setEnvironment()
+            await setAuthConfigEnvironment()
+        }
+        if(flags.providers) {
+            await promptInitProviders()
         }
     })
 
@@ -35,4 +39,4 @@ program
 * Parse the command line arguments
 */
 program.parseAsync(process.argv)
-promptInitConfig()
+//promptInitConfig()

--- a/src/prompts/providers.ts
+++ b/src/prompts/providers.ts
@@ -1,0 +1,29 @@
+import { rawlist } from "@inquirer/prompts"
+import { setEnvironment } from "../utils.js"
+
+
+export const getProvider = async () => {
+    return await rawlist({
+        message: "Select the providers to be configurated",
+        choices: [
+            { name: "Github", value: "GITHUB" },
+            { name: "Google", value: "GOOGLE" },
+            { name: "Facebook", value: "FACEBOOK" },
+            { name: "Auth0", value: "AUTH0" },
+            { name: "Apple", value: "APPLE" },
+            { name: "Instagram", value: "INSTAGRAM" },
+            { name: "Slack", value: "SLACE" },
+            { name: "Spotify", value: "SPOTIFY" },
+        ]
+    })
+}
+
+
+/**
+ * 
+ */
+export const promptInitProviders = async () => {
+    const provider = await getProvider()
+    await setEnvironment(`AUTH_${provider}_ID`, "HERE_MUST_CONTAINS_THE_KEY")
+    await setEnvironment(`AUTH_${provider}_SECRET`, "HERE_MUST_CONTAINS_THE_KEY")
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,10 +2,13 @@
 export type Framework = "NextJs" | "SvelteKit" | "Express" 
 
 export interface FlagOptions {
-    secret: boolean
+    secret: boolean,
+    providers: boolean
 }
 
 export interface PathFile {
     path: string
     content: string
 }
+
+export type ArgsFunction = (...args: any) => void


### PR DESCRIPTION
## Description
This pull request introduces a new module that sets up environment variables for various authentication providers. The module is designed to work seamlessly with Auth.js, making it easier to configure and manage authentication across different platforms.

Supported providers include:

- Google
- Github
- Facebook
- Auth0
- Apple
- Instagram
- Slace

## Usage
To initialize the environment variables for the supported providers, use the -p or --providers flag with the auth-init command:
```bash
auth-init -p
```  
This command will guide you through the setup process, ensuring that the necessary environment variables are correctly configured for each provider.

## Checklist
- [x]  Documentation.
- [x]  The changes don't generate warnings.
- [x]  I have performed a self-review of my own code.
- [ ]  Tests.