### PR TITLE
feat: implement provider imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ logs/
 .env*.production
 .npmrc
 features.md
+auth.ts
+
+# NextConfiguration
+middleware.ts
+app/

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -1,6 +1,6 @@
 import { createSpinner } from "nanospinner"
 import { execAsync, writeConfig } from "../utils.js"
-import { Framework } from "../types.js"
+import { ConfigBase, Framework } from "../types.js"
 import { frameworkInstall, getCodeByFramework } from "./frameworks.js"
 
 
@@ -15,15 +15,16 @@ import { frameworkInstall, getCodeByFramework } from "./frameworks.js"
  * 
  * @param {Framework} framework - The framework to initialize (NextJs, SvelteKit, Express).
  * @param {boolean} create - Whether to create configuration files.
- * @param {string} fileName - The name of the configuration file to be created.
+ * @param {string} baseConfigPath - The name of the configuration file to be created.
  * @returns {Promise<void>} A promise that resolves when the initialization is complete.
  */
-export const initializeAuth = async (framework: Framework, create: boolean, fileName: string): Promise<void> => {
+export const initializeAuth = async (framework: Framework, create: boolean, baseConfigPath: string): Promise<ConfigBase> => {
     installFrameworkAuth(framework)
-    const configFramework = getCodeByFramework(framework, fileName)
+    const configFramework = getCodeByFramework(framework, baseConfigPath)
     if (create) {
         configFramework.map(({ path, content }) => writeConfig(path, content))
     }
+    return { framework, baseConfigPath }
 }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { promptInitConfig } from "./prompts/init.js"
  * Declare and initialize the program
  */
 const program = new Command()
+export const { framework, baseConfigPath } = await promptInitConfig()
 
 /**
  * 
@@ -32,7 +33,7 @@ program
             await setAuthConfigEnvironment()
         }
         if(flags.providers) {
-            await promptInitProviders()
+            await promptInitProviders(framework, baseConfigPath)
         }
     })
 
@@ -40,4 +41,3 @@ program
 * Parse the command line arguments
 */
 program.parseAsync(process.argv)
-await promptInitConfig()

--- a/src/prompts/init.ts
+++ b/src/prompts/init.ts
@@ -33,5 +33,5 @@ export const promptInitConfig = async () => {
     const framework = await selectFramework()
     const configuration = await confirmConfigurationCreation()
     const fileNameConfig = await fileName()
-    initializeAuth(framework, configuration, fileNameConfig)
+    return initializeAuth(framework, configuration, fileNameConfig)
 }

--- a/src/prompts/providers.ts
+++ b/src/prompts/providers.ts
@@ -1,9 +1,10 @@
 import { rawlist } from "@inquirer/prompts"
-import { setEnvironment } from "../utils.js"
+import { addImportProviders, setEnvironment } from "../utils.js"
+import { Framework } from "../types.js"
 
 
 export const getProvider = async () => {
-    return await rawlist({
+    return await rawlist<Capitalize<string>>({
         message: "Select the providers to be configurated",
         choices: [
             { name: "Github", value: "GITHUB" },
@@ -22,8 +23,9 @@ export const getProvider = async () => {
 /**
  * 
  */
-export const promptInitProviders = async () => {
+export const promptInitProviders = async (framework: Framework, baseConfigPath: string) => {
     const provider = await getProvider()
+    addImportProviders(framework, provider, baseConfigPath)
     await setEnvironment(`AUTH_${provider}_ID`, "HERE_MUST_CONTAINS_THE_KEY")
     await setEnvironment(`AUTH_${provider}_SECRET`, "HERE_MUST_CONTAINS_THE_KEY")
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,3 +12,8 @@ export interface PathFile {
 }
 
 export type ArgsFunction = (...args: any) => void
+
+export interface ConfigBase {
+    framework: Framework,
+    baseConfigPath: string
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,8 +2,7 @@ import fs from 'fs';
 import path from "path"
 import { promisify } from "util"
 import { exec } from "child_process"
-import { createSpinner } from 'nanospinner';
-
+import { createSpinner } from 'nanospinner'
 
 /**
  * Create a promise to execute the command for installing
@@ -62,7 +61,7 @@ export const writeConfig = (route: string, content: string): void => {
 
 /**
  * Sets up the environment variables used throughout the project, initially creating
- * the AUTH_SECRET variable. This is mandatory for using auth.js without considering
+ * the environment variables. This is mandatory for using auth.js without considering
  * the framework.
  */
 export const setEnvironment = async (envName: string, value: string): Promise<void> => {
@@ -83,4 +82,35 @@ export const setEnvironment = async (envName: string, value: string): Promise<vo
         return
     }
     createSpinner(`The ${envName} already exists`).warn()
+}
+
+
+/**
+ * Adds the import for a provider to the configuration file if it doesn't already exist.
+ *
+ * @param frameworkPath Path prefix for the provider import (based on framework).
+ * @param providerName The name of the provider to import (capitalized).
+ * @param baseConfigPath The name of the configuration file.
+ */
+export const addImportProviders = (frameworkPath: string, providerName: Capitalize<string>, baseConfigPath: string) => {
+    const readFile = fs.readFileSync(baseConfigPath, "utf-8")
+    const baseImport = `import ${providerName} from "${frameworkPath}/providers/${providerName.toLowerCase()}"`
+    if(containsInFile(readFile, baseImport)) return
+    
+    fs.writeFileSync(baseConfigPath, `${baseImport}\r\n${readFile}` , {
+        flag: "w",
+        encoding: "utf-8"
+    })
+}
+
+
+/**
+ * Checks if a string exists within a file line by line.
+ *
+ * @param {string} fileContent The content of the file to search.
+ * @param {string} searchString The string to search for.
+ * @returns {boolean} True if the search string exists in a line of the file, false otherwise.
+ */
+export const containsInFile = (fileContent: string, searchString: string): boolean => {
+    return fileContent.split(/\r?\n/).some(line => line.trim() === searchString.trim())
 }


### PR DESCRIPTION
## Description
This pull request introduces the implementation for importing providers selected by the user when using the `-p` or `--providers` flag. Additionally, it implements a strategy to share information between multiple layers for the values in the configuration.

- Implemented functionality to import providers based on user selection.
- Implemented a strategy for sharing configuration information across layers.
- Resolve issue from the previous pull request


## Checklist
- [x]  Documentation.
- [x]  The changes don't generate warnings.
- [x]  I have performed a self-review of my own code.
- [ ]  Tests.