### PR TITLE
feat: init a basic project with `auth-init`

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
   "dependencies": {
     "@inquirer/prompts": "^5.5.0",
     "commander": "^12.1.0",
-    "nanospinner": "^1.2.2"
+    "nanospinner": "^1.2.2",
+    "yoctocolors": "^2.1.1"
   },
   "files": [
     "dist"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       nanospinner:
         specifier: ^1.2.2
         version: 1.2.2
+      yoctocolors:
+        specifier: ^2.1.1
+        version: 2.1.1
     devDependencies:
       "@types/inquirer":
         specifier: ^9.0.7
@@ -675,6 +678,10 @@ packages:
     resolution: { integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA== }
     engines: { node: ">=18" }
 
+  yoctocolors@2.1.1:
+    resolution: { integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ== }
+    engines: { node: ">=18" }
+
 snapshots:
   "@esbuild/aix-ppc64@0.21.5":
     optional: true
@@ -1245,3 +1252,5 @@ snapshots:
       strip-ansi: 6.0.1
 
   yoctocolors-cjs@2.1.2: {}
+
+  yoctocolors@2.1.1: {}

--- a/src/commands/provider.ts
+++ b/src/commands/provider.ts
@@ -1,7 +1,8 @@
 import { OptionsCLI } from "@/types.js"
-import { guessFramework, setEnvironment } from "../utils.js"
-import { rawlist, select } from "@inquirer/prompts"
+import { configPath, exists, guessFramework, setEnvironment } from "../utils.js"
+import { confirm, rawlist, select } from "@inquirer/prompts"
 import { supportedFrameworks } from "./init.js"
+import { writeFileSync } from "fs"
 
 const supportedProviders = [
     "GitHub",
@@ -92,6 +93,12 @@ export const provider = async ({ provider, list }: OptionsCLI) => {
             message: "Select the provider to be configured",
             choices: list ? supportedProviders : supportedProviders.splice(0, 10),
         })
+    }
+    if (!exists(".env")) {
+        if (!(await confirm({ message: "File .env not found. Would you like to create it?" }))) {
+            return
+        }
+        writeFileSync(configPath(".env"), "", { flag: "w" })
     }
     const writeEnvironments = await setEnvironment([
         {

--- a/src/commands/secret.ts
+++ b/src/commands/secret.ts
@@ -3,14 +3,17 @@ import { execAsync, setEnvironment } from "../utils.js"
 import { OptionsCLI } from "@/types.js"
 
 /**
- * Sets up the environment variables used throughout the project, initially creating
- * the AUTH_SECRET variable. This is mandatory for using auth.js without considering
- * the framework.
+ * Setup the AUTH_SECRET environment variable  which is mandatory for using Auth.js
+ * without considering the framework.
  */
 export const secret = async ({ size = 32 }: OptionsCLI): Promise<void> => {
     try {
         const { stdout: randomized } = await execAsync(`openssl rand -base64 ${size}`)
-        setEnvironment("AUTH_SECRET", randomized)
+        await setEnvironment({
+            comment: "# AUTH-SECRET IS A RANDOM TOKEN TO ENCRYPT TOKENS, EMAILS AND HASHES",
+            name: "AUTH_SECRET",
+            value: randomized,
+        })
     } catch (error) {
         createSpinner("Error").error({ text: "An error occurred while generating the secret key" })
     }

--- a/src/commands/secret.ts
+++ b/src/commands/secret.ts
@@ -1,6 +1,8 @@
 import { createSpinner } from "nanospinner"
-import { execAsync, setEnvironment } from "../utils.js"
+import { configPath, execAsync, exists, setEnvironment } from "../utils.js"
 import { OptionsCLI } from "@/types.js"
+import { confirm } from "@inquirer/prompts"
+import { writeFileSync } from "fs"
 
 /**
  * Setup the AUTH_SECRET environment variable  which is mandatory for using Auth.js
@@ -8,6 +10,12 @@ import { OptionsCLI } from "@/types.js"
  */
 export const secret = async ({ size = 32 }: OptionsCLI): Promise<void> => {
     try {
+        if (!exists(".env")) {
+            if (!(await confirm({ message: "File .env not found. Would you like to create it?" }))) {
+                return
+            }
+            writeFileSync(configPath(".env"), "", { flag: "w" })
+        }
         const { stdout: randomized } = await execAsync(`openssl rand -base64 ${size}`)
         await setEnvironment({
             comment: "# AUTH-SECRET IS A RANDOM TOKEN TO ENCRYPT TOKENS, EMAILS AND HASHES",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,8 @@
 import "dotenv/config"
 import { Command } from "commander"
 import { init, secret, provider } from "./commands/index.js"
-import { name, description, version, configureOutput, errorColor } from "./utils.js"
+import { name, description, version, configureOutput } from "./utils.js"
+import * as y from "yoctocolors"
 
 /**
  * Declare and initialize the program
@@ -35,13 +36,13 @@ program
     .action(provider)
 
 program
-    .showHelpAfterError(errorColor("You can execute (auth-init --help) to see the available options"))
+    .showHelpAfterError(y.red("You can execute (auth-init --help) to see the available options"))
     .configureOutput(configureOutput)
 
 /**
  * Parse the command line arguments
  */
 program.parseAsync(process.argv).catch(() => {
-    console.error(errorColor(`[ERROR]: the program was closed`))
+    console.error(y.red(`[ERROR]: the program was closed`))
     process.exit(1)
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,11 +5,22 @@ export interface OptionsCLI {
     framework: string | undefined
 }
 
-interface InternalSpinnerOptions {
+export interface InternalSpinnerOptions {
     initial: string
     error?: string
     success?: string
     warning?: string
 }
 
-export type CreateInternalSpinner = (callback: (...args: any) => Promise<void>, options: InternalSpinnerOptions) => void
+export type CreateInternalSpinner = (
+    callback: (...args: any) => Promise<void>,
+    options: InternalSpinnerOptions,
+) => Promise<boolean>
+
+export interface Environment {
+    comment?: string
+    name: string
+    value: string
+}
+
+export type SetEnvironment = (variables: Environment | Environment[]) => Promise<boolean>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -78,7 +78,7 @@ export const setEnvironment: SetEnvironment = async (variables) => {
  * @returns {Promise<string | undefined>} - The name of the framework guessed
  */
 export const guessFramework = async (): Promise<string | undefined> => {
-    if (!existsSync(configPath("package.json"))) return undefined
+    if (!exists("package.json")) return undefined
     const packageJson = JSON.parse(readFileSync(configPath("package.json"), "utf-8"))
     if (!packageJson || (packageJson && !packageJson?.dependencies)) return undefined
     return Object.keys(packageJson.dependencies).find((dependency) =>
@@ -148,3 +148,11 @@ export const getPackageManager = (): string => {
     }
     return "npm"
 }
+
+/**
+ * Checks if the given path exists.
+ *
+ * @param {string} path - The path to check for existence.
+ * @returns {boolean} `true` if the path exists, otherwise `false`.
+ */
+export const exists = (path: string): boolean => existsSync(configPath(path))

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,12 +41,7 @@ export const configPath = (route: string = ""): string => {
  *
  */
 export const setEnvironment: SetEnvironment = async (variables) => {
-    const environments: Environment[] = []
-    if (variables instanceof Array) {
-        environments.push(...variables)
-    } else {
-        environments.push(variables)
-    }
+    const environments: Environment[] = variables instanceof Array ? variables : [variables]
     const filters = await Promise.all(
         environments.map(async ({ name, value, comment = "" }) => {
             return await createInternalSpinner(


### PR DESCRIPTION

# Description

This pull request introduces new features and updates related to the `init`, `provider`, and `secret` commands. The primary focus is on the `init` command to set up a basic project configuration using the `@halvaradop/auth-init` package. Additional updates include the enhancement of color messages for task execution.

### Key Changes
- Install `Auth.js` version compatible with the framework supported.
- Update the `setEnvironment` function.
- Install `yoctocolors`.
- Update color messages in the `createInternalSpinner` function to enhance the visual feedback.


## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
